### PR TITLE
feat: Implement API endpoint to fetch your point history

### DIFF
--- a/src/main/java/com/osc/saferoute/application/service/PointHistoryApplicationService.java
+++ b/src/main/java/com/osc/saferoute/application/service/PointHistoryApplicationService.java
@@ -1,0 +1,30 @@
+package com.osc.saferoute.application.service;
+
+import com.osc.saferoute.domain.model.PointHistory;
+import com.osc.saferoute.domain.repository.PointHistoryRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional; // Optional: if reads need to be transactional
+
+import java.util.List;
+
+@Service // Spring annotation to indicate a service component
+public class PointHistoryApplicationService {
+
+    private final PointHistoryRepository pointHistoryRepository;
+
+    // Constructor injection
+    public PointHistoryApplicationService(PointHistoryRepository pointHistoryRepository) {
+        this.pointHistoryRepository = pointHistoryRepository;
+    }
+
+    // Read operations are often transactional, though it might be managed at a higher level or by default
+    @Transactional(readOnly = true)
+    public List<PointHistory> getPointHistoryForUser(Long userId) {
+        // Basic validation can be added here (e.g., if userId is null)
+        if (userId == null) {
+            // Or throw a custom exception, e.g., InvalidArgumentException
+            throw new IllegalArgumentException("User ID cannot be null.");
+        }
+        return pointHistoryRepository.findByUserId(userId);
+    }
+}

--- a/src/main/java/com/osc/saferoute/controller/PointHistoryController.java
+++ b/src/main/java/com/osc/saferoute/controller/PointHistoryController.java
@@ -22,7 +22,7 @@ public class PointHistoryController {
         this.pointHistoryApplicationService = pointHistoryApplicationService;
     }
 
-    @GetMapping("/{userId}/points/history")
+    @GetMapping("/points/history/{userId}")
     public ResponseEntity<List<PointHistoryDto>> getPointHistory(@PathVariable Long userId) {
         // Basic validation for userId can be done here or in the service
         // For example, ensuring userId is positive, etc.

--- a/src/main/java/com/osc/saferoute/controller/PointHistoryController.java
+++ b/src/main/java/com/osc/saferoute/controller/PointHistoryController.java
@@ -1,0 +1,41 @@
+package com.osc.saferoute.controller;
+
+import com.osc.saferoute.application.service.PointHistoryApplicationService;
+import com.osc.saferoute.controller.dto.PointHistoryDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/users") // Base path for user-related endpoints
+public class PointHistoryController {
+
+    private final PointHistoryApplicationService pointHistoryApplicationService;
+
+    // Constructor injection
+    public PointHistoryController(PointHistoryApplicationService pointHistoryApplicationService) {
+        this.pointHistoryApplicationService = pointHistoryApplicationService;
+    }
+
+    @GetMapping("/{userId}/points/history")
+    public ResponseEntity<List<PointHistoryDto>> getPointHistory(@PathVariable Long userId) {
+        // Basic validation for userId can be done here or in the service
+        // For example, ensuring userId is positive, etc.
+        if (userId == null || userId <= 0) {
+             // Returning bad request if userId is invalid
+            return ResponseEntity.badRequest().build();
+        }
+
+        List<PointHistoryDto> historyDtos = pointHistoryApplicationService.getPointHistoryForUser(userId)
+                .stream()
+                .map(PointHistoryDto::fromDomain) // Convert domain object to DTO
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(historyDtos);
+    }
+}

--- a/src/main/java/com/osc/saferoute/controller/dto/PointHistoryDto.java
+++ b/src/main/java/com/osc/saferoute/controller/dto/PointHistoryDto.java
@@ -1,0 +1,55 @@
+package com.osc.saferoute.controller.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.osc.saferoute.domain.model.PointHistory;
+
+import java.time.LocalDateTime;
+
+public class PointHistoryDto {
+
+    private Long historyId;
+
+    @JsonFormat(pattern="yyyy-MM-dd HH:mm:ss") // Standard date-time format for APIs
+    private LocalDateTime transactionDatetime;
+
+    private String reasonDetails;
+    private int pointsChange;
+
+    // Private constructor to enforce usage of factory method
+    private PointHistoryDto(Long historyId, LocalDateTime transactionDatetime, String reasonDetails, int pointsChange) {
+        this.historyId = historyId;
+        this.transactionDatetime = transactionDatetime;
+        this.reasonDetails = reasonDetails;
+        this.pointsChange = pointsChange;
+    }
+
+    // Getters are needed for Jackson serialization
+    public Long getHistoryId() {
+        return historyId;
+    }
+
+    public LocalDateTime getTransactionDatetime() {
+        return transactionDatetime;
+    }
+
+    public String getReasonDetails() {
+        return reasonDetails;
+    }
+
+    public int getPointsChange() {
+        return pointsChange;
+    }
+
+    // Static factory method for conversion from Domain object
+    public static PointHistoryDto fromDomain(PointHistory domain) {
+        if (domain == null) {
+            return null;
+        }
+        return new PointHistoryDto(
+                domain.getHistoryId(),
+                domain.getTransactionDatetime(),
+                domain.getReasonDetails(),
+                domain.getPointsChange()
+        );
+    }
+}

--- a/src/main/java/com/osc/saferoute/domain/model/PointHistory.java
+++ b/src/main/java/com/osc/saferoute/domain/model/PointHistory.java
@@ -1,0 +1,62 @@
+package com.osc.saferoute.domain.model;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public class PointHistory {
+
+    private final Long historyId;
+    private final LocalDateTime transactionDatetime;
+    private final String reasonDetails;
+    private final int pointsChange;
+
+    public PointHistory(Long historyId, LocalDateTime transactionDatetime, String reasonDetails, int pointsChange) {
+        // Consider adding validation logic here if necessary (e.g., reasonDetails not null)
+        this.historyId = historyId;
+        this.transactionDatetime = transactionDatetime;
+        this.reasonDetails = reasonDetails;
+        this.pointsChange = pointsChange;
+    }
+
+    public Long getHistoryId() {
+        return historyId;
+    }
+
+    public LocalDateTime getTransactionDatetime() {
+        return transactionDatetime;
+    }
+
+    public String getReasonDetails() {
+        return reasonDetails;
+    }
+
+    public int getPointsChange() {
+        return pointsChange;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PointHistory that = (PointHistory) o;
+        return pointsChange == that.pointsChange &&
+               Objects.equals(historyId, that.historyId) &&
+               Objects.equals(transactionDatetime, that.transactionDatetime) &&
+               Objects.equals(reasonDetails, that.reasonDetails);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(historyId, transactionDatetime, reasonDetails, pointsChange);
+    }
+
+    @Override
+    public String toString() {
+        return "PointHistory{" +
+               "historyId=" + historyId +
+               ", transactionDatetime=" + transactionDatetime +
+               ", reasonDetails='" + reasonDetails + '\'' +
+               ", pointsChange=" + pointsChange +
+               '}';
+    }
+}

--- a/src/main/java/com/osc/saferoute/domain/repository/PointHistoryRepository.java
+++ b/src/main/java/com/osc/saferoute/domain/repository/PointHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.osc.saferoute.domain.repository;
+
+import com.osc.saferoute.domain.model.PointHistory;
+import java.util.List;
+
+public interface PointHistoryRepository {
+    List<PointHistory> findByUserId(Long userId);
+}

--- a/src/main/java/com/osc/saferoute/infrastructure/mybatis/entity/PointHistoryEntity.java
+++ b/src/main/java/com/osc/saferoute/infrastructure/mybatis/entity/PointHistoryEntity.java
@@ -1,0 +1,57 @@
+package com.osc.saferoute.infrastructure.mybatis.entity;
+
+import java.sql.Timestamp; // Using java.sql.Timestamp for direct MyBatis mapping
+
+public class PointHistoryEntity {
+
+    private Long historyId;
+    private Long userId;
+    private int pointsChange;
+    private String reasonDetails;
+    private Timestamp transactionDatetime; // MyBatis works well with Timestamp for DATETIME columns
+
+    // Default constructor - often needed by ORMs/mappers
+    public PointHistoryEntity() {
+    }
+
+    // Getters and Setters
+    public Long getHistoryId() {
+        return historyId;
+    }
+
+    public void setHistoryId(Long historyId) {
+        this.historyId = historyId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public int getPointsChange() {
+        return pointsChange;
+    }
+
+    public void setPointsChange(int pointsChange) {
+        this.pointsChange = pointsChange;
+    }
+
+    public String getReasonDetails() {
+        return reasonDetails;
+    }
+
+    public void setReasonDetails(String reasonDetails) {
+        this.reasonDetails = reasonDetails;
+    }
+
+    public Timestamp getTransactionDatetime() {
+        return transactionDatetime;
+    }
+
+    public void setTransactionDatetime(Timestamp transactionDatetime) {
+        this.transactionDatetime = transactionDatetime;
+    }
+}

--- a/src/main/java/com/osc/saferoute/infrastructure/mybatis/mapper/PointHistoryMapper.java
+++ b/src/main/java/com/osc/saferoute/infrastructure/mybatis/mapper/PointHistoryMapper.java
@@ -1,0 +1,12 @@
+package com.osc.saferoute.infrastructure.mybatis.mapper;
+
+import com.osc.saferoute.infrastructure.mybatis.entity.PointHistoryEntity;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface PointHistoryMapper {
+    List<PointHistoryEntity> findByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/osc/saferoute/infrastructure/mybatis/repository/PointHistoryRepositoryImpl.java
+++ b/src/main/java/com/osc/saferoute/infrastructure/mybatis/repository/PointHistoryRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.osc.saferoute.infrastructure.mybatis.repository;
+
+import com.osc.saferoute.domain.model.PointHistory;
+import com.osc.saferoute.domain.repository.PointHistoryRepository;
+import com.osc.saferoute.infrastructure.mybatis.entity.PointHistoryEntity;
+import com.osc.saferoute.infrastructure.mybatis.mapper.PointHistoryMapper;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Repository // Spring annotation to indicate a repository component
+public class PointHistoryRepositoryImpl implements PointHistoryRepository {
+
+    private final PointHistoryMapper pointHistoryMapper;
+
+    // Constructor injection
+    public PointHistoryRepositoryImpl(PointHistoryMapper pointHistoryMapper) {
+        this.pointHistoryMapper = pointHistoryMapper;
+    }
+
+    @Override
+    public List<PointHistory> findByUserId(Long userId) {
+        List<PointHistoryEntity> entities = pointHistoryMapper.findByUserId(userId);
+        return entities.stream()
+                .map(this::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    // Private helper method to convert Entity to Domain object
+    private PointHistory toDomain(PointHistoryEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        // Ensure Timestamp is converted to LocalDateTime for the domain model
+        LocalDateTime transactionDateTime = entity.getTransactionDatetime() != null ?
+                                            entity.getTransactionDatetime().toLocalDateTime() : null;
+        return new PointHistory(
+                entity.getHistoryId(),
+                transactionDateTime,
+                entity.getReasonDetails(),
+                entity.getPointsChange()
+        );
+    }
+}

--- a/src/main/resources/mappers/PointHistoryMapper.xml
+++ b/src/main/resources/mappers/PointHistoryMapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.osc.saferoute.infrastructure.mybatis.mapper.PointHistoryMapper">
+
+    <resultMap id="PointHistoryEntityResultMap" type="com.osc.saferoute.infrastructure.mybatis.entity.PointHistoryEntity">
+        <id property="historyId" column="history_id"/>
+        <result property="userId" column="user_id"/>
+        <result property="pointsChange" column="points_change"/>
+        <result property="reasonDetails" column="reason_details"/>
+        <result property="transactionDatetime" column="transaction_datetime"/>
+    </resultMap>
+
+    <select id="findByUserId" resultMap="PointHistoryEntityResultMap">
+        SELECT
+            history_id,
+            user_id,
+            points_change,
+            reason_details,
+            transaction_datetime
+        FROM
+            point_history
+        WHERE
+            user_id = #{userId}
+        ORDER BY
+            transaction_datetime DESC;
+    </select>
+</mapper>


### PR DESCRIPTION
Adds a new GET endpoint `/api/users/{userId}/points/history` to retrieve the points earning and redemption history for a given user.

This implementation adheres to the existing Onion architecture:
- Domain: Added `PointHistory` model and `PointHistoryRepository` interface.
- Infrastructure: Implemented `PointHistoryRepositoryImpl` using MyBatis, including `PointHistoryEntity`, `PointHistoryMapper` interface, and `PointHistoryMapper.xml` for SQL queries. The SQL query fetches records from the `point_history` table and orders them by transaction date.
- Application: Created `PointHistoryApplicationService` to orchestrate fetching data via the repository.
- Controller: Introduced `PointHistoryController` to expose the API endpoint and `PointHistoryDto` for data transfer.

The endpoint returns a list of point history records, including transaction details, points changed, and the date/time of the transaction.