### PR TITLE
feat: Initial implementation of route rankings API structure

### DIFF
--- a/src/main/java/com/osc/saferoute/application/service/RouteRankingService.java
+++ b/src/main/java/com/osc/saferoute/application/service/RouteRankingService.java
@@ -1,0 +1,9 @@
+package com.osc.saferoute.application.service;
+
+import com.osc.saferoute.controller.dto.RouteRankingResponse;
+
+import java.util.List;
+
+public interface RouteRankingService {
+    List<RouteRankingResponse> getRouteRankings(String criteria);
+}

--- a/src/main/java/com/osc/saferoute/application/service/RouteRankingServiceImpl.java
+++ b/src/main/java/com/osc/saferoute/application/service/RouteRankingServiceImpl.java
@@ -1,7 +1,8 @@
 package com.osc.saferoute.application.service;
 
 import com.osc.saferoute.controller.dto.RouteRankingResponse;
-import com.osc.saferoute.domain.repository.EvacuationRouteRepository; // This repository will be used later
+import com.osc.saferoute.domain.model.RouteRankingData; // Added import
+import com.osc.saferoute.domain.repository.EvacuationRouteRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,9 +21,22 @@ public class RouteRankingServiceImpl implements RouteRankingService {
 
     @Override
     public List<RouteRankingResponse> getRouteRankings(String criteria) {
-        // Placeholder implementation:
-        // This will be replaced with actual logic to fetch and rank routes
-        // based on criteria using evacuationRouteRepository.
-        return new ArrayList<>();
+        List<RouteRankingData> rankingDataList = evacuationRouteRepository.findRouteRankingDataByCriteria(criteria);
+        List<RouteRankingResponse> responseList = new ArrayList<>();
+
+        for (int i = 0; i < rankingDataList.size(); i++) {
+            RouteRankingData data = rankingDataList.get(i);
+            RouteRankingResponse responseDto = new RouteRankingResponse();
+
+            responseDto.setRouteId(data.routeId());
+            responseDto.setUserNickname(data.userNickname());
+            responseDto.setDistance(data.distance());
+            responseDto.setEstimatedTime(data.estimatedTime());
+            responseDto.setSelfAssessedSafety(data.selfAssessedSafety());
+            responseDto.setRank(i + 1); // Rank is 1-based
+
+            responseList.add(responseDto);
+        }
+        return responseList;
     }
 }

--- a/src/main/java/com/osc/saferoute/application/service/RouteRankingServiceImpl.java
+++ b/src/main/java/com/osc/saferoute/application/service/RouteRankingServiceImpl.java
@@ -1,0 +1,28 @@
+package com.osc.saferoute.application.service;
+
+import com.osc.saferoute.controller.dto.RouteRankingResponse;
+import com.osc.saferoute.domain.repository.EvacuationRouteRepository; // This repository will be used later
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class RouteRankingServiceImpl implements RouteRankingService {
+
+    private final EvacuationRouteRepository evacuationRouteRepository;
+
+    @Autowired
+    public RouteRankingServiceImpl(EvacuationRouteRepository evacuationRouteRepository) {
+        this.evacuationRouteRepository = evacuationRouteRepository;
+    }
+
+    @Override
+    public List<RouteRankingResponse> getRouteRankings(String criteria) {
+        // Placeholder implementation:
+        // This will be replaced with actual logic to fetch and rank routes
+        // based on criteria using evacuationRouteRepository.
+        return new ArrayList<>();
+    }
+}

--- a/src/main/java/com/osc/saferoute/controller/RouteRankingController.java
+++ b/src/main/java/com/osc/saferoute/controller/RouteRankingController.java
@@ -1,0 +1,33 @@
+package com.osc.saferoute.controller;
+
+import com.osc.saferoute.controller.dto.RouteRankingResponse;
+import com.osc.saferoute.application.service.RouteRankingService; // This service will be created later
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/rankings/routes")
+public class RouteRankingController {
+
+    private final RouteRankingService routeRankingService;
+
+    @Autowired
+    public RouteRankingController(RouteRankingService routeRankingService) {
+        this.routeRankingService = routeRankingService;
+    }
+
+    @GetMapping("/{criteria}")
+    public ResponseEntity<List<RouteRankingResponse>> getRouteRankings(@PathVariable String criteria) {
+        // Placeholder implementation:
+        // List<RouteRankingResponse> rankings = routeRankingService.getRankingsByCriteria(criteria);
+        // return ResponseEntity.ok(rankings);
+        return ResponseEntity.ok(new ArrayList<>());
+    }
+}

--- a/src/main/java/com/osc/saferoute/controller/dto/RouteRankingResponse.java
+++ b/src/main/java/com/osc/saferoute/controller/dto/RouteRankingResponse.java
@@ -1,0 +1,17 @@
+package com.osc.saferoute.controller.dto;
+
+import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RouteRankingResponse {
+    private String routeId;
+    private String userNickname;
+    private Double distance;
+    private Integer estimatedTime;
+    private Integer selfAssessedSafety;
+    private Integer rank;
+}

--- a/src/main/java/com/osc/saferoute/domain/model/RouteRankingData.java
+++ b/src/main/java/com/osc/saferoute/domain/model/RouteRankingData.java
@@ -1,0 +1,10 @@
+package com.osc.saferoute.domain.model;
+
+public record RouteRankingData(
+    String routeId,
+    String userNickname,
+    Double distance,
+    Integer estimatedTime,
+    Integer selfAssessedSafety
+) {
+}

--- a/src/main/java/com/osc/saferoute/domain/repository/EvacuationRouteRepository.java
+++ b/src/main/java/com/osc/saferoute/domain/repository/EvacuationRouteRepository.java
@@ -1,6 +1,7 @@
 package com.osc.saferoute.domain.repository;
 
 import com.osc.saferoute.domain.model.EvacuationRoute;
+import com.osc.saferoute.domain.model.RouteRankingData; // Added import
 import java.util.List;
 
 public interface EvacuationRouteRepository {
@@ -14,4 +15,13 @@ public interface EvacuationRouteRepository {
      *         Returns an empty list if no primary routes are found.
      */
     List<EvacuationRoute> findPrimaryByUserId(String userId);
+
+    /**
+     * Finds route ranking data based on specified criteria.
+     *
+     * @param criteria The criteria to filter and rank routes (e.g., "fastest", "shortest", "safest").
+     * @return A list of RouteRankingData objects.
+     *         Returns an empty list if no data matches the criteria.
+     */
+    List<RouteRankingData> findRouteRankingDataByCriteria(String criteria);
 }

--- a/src/main/java/com/osc/saferoute/infrastructure/mybatis/mapper/EvacuationRouteMapper.java
+++ b/src/main/java/com/osc/saferoute/infrastructure/mybatis/mapper/EvacuationRouteMapper.java
@@ -1,6 +1,7 @@
 package com.osc.saferoute.infrastructure.mybatis.mapper;
 
 import com.osc.saferoute.domain.model.EvacuationRoute; // Using domain model directly
+import com.osc.saferoute.domain.model.RouteRankingData; // Added import
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import java.util.List;
@@ -17,4 +18,13 @@ public interface EvacuationRouteMapper {
      * @return A list of EvacuationRoute objects that are marked as primary for the user.
      */
     List<EvacuationRoute> findPrimaryByUserId(@Param("userId") String userId);
+
+    /**
+     * Finds route ranking data based on specified criteria.
+     * This method corresponds to the select statement with id="findRouteRankingDataByCriteria" in EvacuationRouteMapper.xml.
+     *
+     * @param criteria The criteria to filter and rank routes (e.g., "fastest", "shortest", "safest").
+     * @return A list of RouteRankingData objects.
+     */
+    List<RouteRankingData> findRouteRankingDataByCriteria(@Param("criteria") String criteria);
 }

--- a/src/test/java/com/osc/saferoute/application/service/RouteRankingServiceImplTest.java
+++ b/src/test/java/com/osc/saferoute/application/service/RouteRankingServiceImplTest.java
@@ -1,0 +1,81 @@
+package com.osc.saferoute.application.service;
+
+import com.osc.saferoute.controller.dto.RouteRankingResponse;
+import com.osc.saferoute.domain.model.RouteRankingData;
+import com.osc.saferoute.domain.repository.EvacuationRouteRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RouteRankingServiceImplTest {
+
+    @Mock
+    private EvacuationRouteRepository evacuationRouteRepository;
+
+    @InjectMocks
+    private RouteRankingServiceImpl routeRankingService;
+
+    @Test
+    @DisplayName("getRouteRankings should return ranked DTOs for 'fastest' criteria")
+    void getRouteRankings_whenFastestCriteria_shouldReturnRankedDtos() {
+        // Arrange
+        String criteria = "fastest";
+        RouteRankingData data1 = new RouteRankingData("route001", "UserA", 1500.0, 20, 4);
+        RouteRankingData data2 = new RouteRankingData("route002", "UserB", 1200.0, 15, 5);
+        List<RouteRankingData> mockDataList = Arrays.asList(data1, data2);
+
+        when(evacuationRouteRepository.findRouteRankingDataByCriteria(criteria)).thenReturn(mockDataList);
+
+        // Act
+        List<RouteRankingResponse> result = routeRankingService.getRouteRankings(criteria);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(2, result.size());
+
+        // Check data mapping and rank for the first element
+        RouteRankingResponse response1 = result.get(0);
+        assertEquals(data1.routeId(), response1.getRouteId());
+        assertEquals(data1.userNickname(), response1.getUserNickname());
+        assertEquals(data1.distance(), response1.getDistance());
+        assertEquals(data1.estimatedTime(), response1.getEstimatedTime());
+        assertEquals(data1.selfAssessedSafety(), response1.getSelfAssessedSafety());
+        assertEquals(1, response1.getRank()); // Rank should be 1
+
+        // Check data mapping and rank for the second element
+        RouteRankingResponse response2 = result.get(1);
+        assertEquals(data2.routeId(), response2.getRouteId());
+        assertEquals(data2.userNickname(), response2.getUserNickname());
+        assertEquals(2, response2.getRank()); // Rank should be 2
+
+        verify(evacuationRouteRepository, times(1)).findRouteRankingDataByCriteria(criteria);
+    }
+
+    @Test
+    @DisplayName("getRouteRankings should return empty list when repository returns empty")
+    void getRouteRankings_whenRepositoryReturnsEmpty_shouldReturnEmptyList() {
+        // Arrange
+        String criteria = "safest";
+        when(evacuationRouteRepository.findRouteRankingDataByCriteria(criteria)).thenReturn(Collections.emptyList());
+
+        // Act
+        List<RouteRankingResponse> result = routeRankingService.getRouteRankings(criteria);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        verify(evacuationRouteRepository, times(1)).findRouteRankingDataByCriteria(criteria);
+    }
+}

--- a/src/test/java/com/osc/saferoute/controller/RouteRankingControllerTest.java
+++ b/src/test/java/com/osc/saferoute/controller/RouteRankingControllerTest.java
@@ -1,0 +1,87 @@
+package com.osc.saferoute.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.osc.saferoute.application.service.RouteRankingService;
+import com.osc.saferoute.controller.dto.RouteRankingResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(RouteRankingController.class)
+class RouteRankingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RouteRankingService routeRankingService; // from com.osc.saferoute.application.service
+
+    @Autowired
+    private ObjectMapper objectMapper; // For converting objects to JSON strings if needed for debugging
+
+    @Test
+    @DisplayName("GET /api/v1/rankings/routes/fastest - Success")
+    void getRouteRankings_whenFastestCriteria_shouldReturnOkAndRankedList() throws Exception {
+        // Arrange
+        String criteria = "fastest";
+        RouteRankingResponse response1 = new RouteRankingResponse("route001", "UserA", 1500.0, 20, 4, 1);
+        RouteRankingResponse response2 = new RouteRankingResponse("route002", "UserB", 1200.0, 15, 5, 2);
+        List<RouteRankingResponse> mockResponseList = Arrays.asList(response1, response2);
+
+        when(routeRankingService.getRouteRankings(criteria)).thenReturn(mockResponseList);
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/rankings/routes/{criteria}", criteria)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // Assert
+        resultActions.andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].routeId", is(response1.getRouteId())))
+                .andExpect(jsonPath("$[0].userNickname", is(response1.getUserNickname())))
+                .andExpect(jsonPath("$[0].distance", is(response1.getDistance())))
+                .andExpect(jsonPath("$[0].estimatedTime", is(response1.getEstimatedTime())))
+                .andExpect(jsonPath("$[0].selfAssessedSafety", is(response1.getSelfAssessedSafety())))
+                .andExpect(jsonPath("$[0].rank", is(response1.getRank())))
+                .andExpect(jsonPath("$[1].routeId", is(response2.getRouteId())))
+                .andExpect(jsonPath("$[1].rank", is(response2.getRank())));
+
+        verify(routeRankingService, times(1)).getRouteRankings(criteria);
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/rankings/routes/empty - Service returns empty list")
+    void getRouteRankings_whenServiceReturnsEmptyList_shouldReturnOkAndEmptyArray() throws Exception {
+        // Arrange
+        String criteria = "emptyCriteria";
+        when(routeRankingService.getRouteRankings(anyString())).thenReturn(Collections.emptyList());
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/rankings/routes/{criteria}", criteria)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // Assert
+        resultActions.andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(0))); // Checks if the root is an array of size 0
+
+        verify(routeRankingService, times(1)).getRouteRankings(criteria);
+    }
+}


### PR DESCRIPTION
This commit includes the initial setup for the API endpoint to fetch evacuation route rankings.

Changes made:
- Created the new branch `feature/fetchRouteRankings`.
- Defined `RouteRankingResponse.java` DTO for the API response.
- Created `RouteRankingController.java` with the endpoint `/api/v1/rankings/routes/{criteria}`.
- Implemented `RouteRankingService` interface and a placeholder `RouteRankingServiceImpl`.
- Defined `RouteRankingData.java` record for data transfer from the repository.
- Added `findRouteRankingDataByCriteria` method to `EvacuationRouteRepository.java`.
- Implemented MyBatis `EvacuationRouteMapper` (Java and XML) to fetch data from `evacuation_routes` and `users` tables, including dynamic sorting based on criteria (fastest, shortest, safest).

The core ranking logic within the service and comprehensive unit tests are pending and will be addressed in subsequent commits.