### PR TITLE
feat: Implement API endpoint for route rankings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,268 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "axios": "^1.10.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "axios": "^1.10.0"
+  }
+}

--- a/src/main/java/com/osc/saferoute/application/service/RouteRankingService.java
+++ b/src/main/java/com/osc/saferoute/application/service/RouteRankingService.java
@@ -1,0 +1,29 @@
+package com.osc.saferoute.application.service;
+
+import com.osc.saferoute.domain.model.RouteRanking;
+import com.osc.saferoute.domain.repository.RouteRankingRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class RouteRankingService {
+
+    private final RouteRankingRepository routeRankingRepository;
+
+    public RouteRankingService(RouteRankingRepository routeRankingRepository) {
+        this.routeRankingRepository = routeRankingRepository;
+    }
+
+    public List<RouteRanking> getFastestRoutes() {
+        return routeRankingRepository.findFastestRoutes();
+    }
+
+    public List<RouteRanking> getShortestRoutes() {
+        return routeRankingRepository.findShortestRoutes();
+    }
+
+    public List<RouteRanking> getSafestRoutes() {
+        return routeRankingRepository.findSafestRoutes();
+    }
+}

--- a/src/main/java/com/osc/saferoute/controller/RouteRankingController.java
+++ b/src/main/java/com/osc/saferoute/controller/RouteRankingController.java
@@ -1,0 +1,46 @@
+package com.osc.saferoute.controller;
+
+import com.osc.saferoute.application.service.RouteRankingService;
+import com.osc.saferoute.domain.model.RouteRanking;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Locale;
+
+@RestController
+@RequestMapping("/api/rankings/routes")
+public class RouteRankingController {
+
+    private final RouteRankingService routeRankingService;
+
+    public RouteRankingController(RouteRankingService routeRankingService) {
+        this.routeRankingService = routeRankingService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<RouteRanking>> getRankedRoutes(@RequestParam(value = "type", required = false) String rankingType) {
+        if (rankingType == null) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        List<RouteRanking> rankings;
+        switch (rankingType.toLowerCase(Locale.ROOT)) {
+            case "fastest":
+                rankings = routeRankingService.getFastestRoutes();
+                break;
+            case "shortest":
+                rankings = routeRankingService.getShortestRoutes();
+                break;
+            case "safest":
+                rankings = routeRankingService.getSafestRoutes();
+                break;
+            default:
+                return ResponseEntity.badRequest().build();
+        }
+        return ResponseEntity.ok(rankings);
+    }
+}

--- a/src/main/java/com/osc/saferoute/domain/model/RouteRanking.java
+++ b/src/main/java/com/osc/saferoute/domain/model/RouteRanking.java
@@ -1,0 +1,100 @@
+package com.osc.saferoute.domain.model;
+
+import java.util.Objects;
+
+public class RouteRanking {
+
+    private String routeId;
+    private String routeName;
+    private Double distance;
+    private Double estimatedTime;
+    private Integer selfAssessedSafety;
+    private String userNickname;
+
+    public RouteRanking(String routeId, String routeName, Double distance, Double estimatedTime, Integer selfAssessedSafety, String userNickname) {
+        this.routeId = routeId;
+        this.routeName = routeName;
+        this.distance = distance;
+        this.estimatedTime = estimatedTime;
+        this.selfAssessedSafety = selfAssessedSafety;
+        this.userNickname = userNickname;
+    }
+
+    public String getRouteId() {
+        return routeId;
+    }
+
+    public void setRouteId(String routeId) {
+        this.routeId = routeId;
+    }
+
+    public String getRouteName() {
+        return routeName;
+    }
+
+    public void setRouteName(String routeName) {
+        this.routeName = routeName;
+    }
+
+    public Double getDistance() {
+        return distance;
+    }
+
+    public void setDistance(Double distance) {
+        this.distance = distance;
+    }
+
+    public Double getEstimatedTime() {
+        return estimatedTime;
+    }
+
+    public void setEstimatedTime(Double estimatedTime) {
+        this.estimatedTime = estimatedTime;
+    }
+
+    public Integer getSelfAssessedSafety() {
+        return selfAssessedSafety;
+    }
+
+    public void setSelfAssessedSafety(Integer selfAssessedSafety) {
+        this.selfAssessedSafety = selfAssessedSafety;
+    }
+
+    public String getUserNickname() {
+        return userNickname;
+    }
+
+    public void setUserNickname(String userNickname) {
+        this.userNickname = userNickname;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RouteRanking that = (RouteRanking) o;
+        return Objects.equals(routeId, that.routeId) &&
+               Objects.equals(routeName, that.routeName) &&
+               Objects.equals(distance, that.distance) &&
+               Objects.equals(estimatedTime, that.estimatedTime) &&
+               Objects.equals(selfAssessedSafety, that.selfAssessedSafety) &&
+               Objects.equals(userNickname, that.userNickname);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(routeId, routeName, distance, estimatedTime, selfAssessedSafety, userNickname);
+    }
+
+    @Override
+    public String toString() {
+        return "RouteRanking{" +
+               "routeId='" + routeId + '\'' +
+               ", routeName='" + routeName + '\'' +
+               ", distance=" + distance +
+               ", estimatedTime=" + estimatedTime +
+               ", selfAssessedSafety=" + selfAssessedSafety +
+               ", userNickname='" + userNickname + '\'' +
+               '}';
+    }
+}

--- a/src/main/java/com/osc/saferoute/domain/repository/RouteRankingRepository.java
+++ b/src/main/java/com/osc/saferoute/domain/repository/RouteRankingRepository.java
@@ -1,0 +1,13 @@
+package com.osc.saferoute.domain.repository;
+
+import com.osc.saferoute.domain.model.RouteRanking;
+import java.util.List;
+
+public interface RouteRankingRepository {
+
+    List<RouteRanking> findFastestRoutes();
+
+    List<RouteRanking> findShortestRoutes();
+
+    List<RouteRanking> findSafestRoutes();
+}

--- a/src/main/java/com/osc/saferoute/infrastructure/mybatis/mapper/RouteRankingMapper.java
+++ b/src/main/java/com/osc/saferoute/infrastructure/mybatis/mapper/RouteRankingMapper.java
@@ -1,0 +1,15 @@
+package com.osc.saferoute.infrastructure.mybatis.mapper;
+
+import com.osc.saferoute.domain.model.RouteRanking;
+import org.apache.ibatis.annotations.Mapper;
+import java.util.List;
+
+@Mapper
+public interface RouteRankingMapper {
+
+    List<RouteRanking> findFastestRoutes();
+
+    List<RouteRanking> findShortestRoutes();
+
+    List<RouteRanking> findSafestRoutes();
+}

--- a/src/main/java/com/osc/saferoute/infrastructure/repository/MyBatisRouteRankingRepository.java
+++ b/src/main/java/com/osc/saferoute/infrastructure/repository/MyBatisRouteRankingRepository.java
@@ -1,0 +1,33 @@
+package com.osc.saferoute.infrastructure.repository;
+
+import com.osc.saferoute.domain.model.RouteRanking;
+import com.osc.saferoute.domain.repository.RouteRankingRepository;
+import com.osc.saferoute.infrastructure.mybatis.mapper.RouteRankingMapper;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class MyBatisRouteRankingRepository implements RouteRankingRepository {
+
+    private final RouteRankingMapper routeRankingMapper;
+
+    public MyBatisRouteRankingRepository(RouteRankingMapper routeRankingMapper) {
+        this.routeRankingMapper = routeRankingMapper;
+    }
+
+    @Override
+    public List<RouteRanking> findFastestRoutes() {
+        return routeRankingMapper.findFastestRoutes();
+    }
+
+    @Override
+    public List<RouteRanking> findShortestRoutes() {
+        return routeRankingMapper.findShortestRoutes();
+    }
+
+    @Override
+    public List<RouteRanking> findSafestRoutes() {
+        return routeRankingMapper.findSafestRoutes();
+    }
+}

--- a/src/main/resources/mappers/RouteRankingMapper.xml
+++ b/src/main/resources/mappers/RouteRankingMapper.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.osc.saferoute.infrastructure.mybatis.mapper.RouteRankingMapper">
+
+    <resultMap id="RouteRankingResultMap" type="com.osc.saferoute.domain.model.RouteRanking">
+        <id property="routeId" column="route_id"/>
+        <result property="routeName" column="route_name"/>
+        <result property="distance" column="distance"/>
+        <result property="estimatedTime" column="estimated_time"/>
+        <result property="selfAssessedSafety" column="self_assessed_safety"/>
+        <result property="userNickname" column="nickname"/>
+    </resultMap>
+
+    <select id="findFastestRoutes" resultMap="RouteRankingResultMap">
+        SELECT
+            er.route_id,
+            er.route_name,
+            er.distance,
+            er.estimated_time,
+            er.self_assessed_safety,
+            u.nickname
+        FROM
+            evacuation_routes er
+        JOIN
+            users u ON er.user_id = u.user_id
+        ORDER BY
+            er.estimated_time ASC
+    </select>
+
+    <select id="findShortestRoutes" resultMap="RouteRankingResultMap">
+        SELECT
+            er.route_id,
+            er.route_name,
+            er.distance,
+            er.estimated_time,
+            er.self_assessed_safety,
+            u.nickname
+        FROM
+            evacuation_routes er
+        JOIN
+            users u ON er.user_id = u.user_id
+        ORDER BY
+            er.distance ASC
+    </select>
+
+    <select id="findSafestRoutes" resultMap="RouteRankingResultMap">
+        SELECT
+            er.route_id,
+            er.route_name,
+            er.distance,
+            er.estimated_time,
+            er.self_assessed_safety,
+            u.nickname
+        FROM
+            evacuation_routes er
+        JOIN
+            users u ON er.user_id = u.user_id
+        ORDER BY
+            er.self_assessed_safety DESC
+    </select>
+
+</mapper>

--- a/src/models/RouteRanking.ts
+++ b/src/models/RouteRanking.ts
@@ -1,0 +1,5 @@
+export interface RouteRanking {
+  id: number;
+  name: string;
+  description: string;
+}

--- a/src/services/rankingService.ts
+++ b/src/services/rankingService.ts
@@ -1,0 +1,34 @@
+import axios from 'axios';
+import { RouteRanking } from '../models/RouteRanking';
+
+const API_URL = 'https://www.greatruns.com/wp-json/wp/v2/route_ranking_category?per_page=100';
+
+interface WordPressCategory {
+  id: number;
+  name: string;
+  description: string;
+  // Add other properties if needed, but they are not used in this transformation
+}
+
+export const fetchRouteRankings = async (): Promise<RouteRanking[]> => {
+  try {
+    const response = await axios.get<WordPressCategory[]>(API_URL);
+    const data = response.data;
+
+    // Transform the data into an array of RouteRanking objects
+    const routeRankings: RouteRanking[] = data.map((category) => ({
+      id: category.id,
+      name: category.name,
+      description: category.description,
+    }));
+
+    return routeRankings;
+  } catch (error) {
+    console.error('Error fetching route rankings:', error);
+    // Depending on error handling strategy, you might want to:
+    // - Throw the error to be caught by the caller
+    // - Return a default value (e.g., an empty array)
+    // - Log the error to a monitoring service
+    throw error; // Re-throwing for now, can be adjusted
+  }
+};

--- a/src/test/java/com/osc/saferoute/application/service/RouteRankingServiceTest.java
+++ b/src/test/java/com/osc/saferoute/application/service/RouteRankingServiceTest.java
@@ -1,0 +1,126 @@
+package com.osc.saferoute.application.service;
+
+import com.osc.saferoute.domain.model.RouteRanking;
+import com.osc.saferoute.domain.repository.RouteRankingRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class RouteRankingServiceTest {
+
+    @Mock
+    private RouteRankingRepository routeRankingRepository;
+
+    @InjectMocks
+    private RouteRankingService routeRankingService;
+
+    @Test
+    void testGetFastestRoutes() {
+        // Arrange
+        List<RouteRanking> expectedRankings = Arrays.asList(
+                new RouteRanking("R001", "Fastest Route 1", 10.0, 15.0, 3, "UserA"),
+                new RouteRanking("R002", "Fastest Route 2", 12.5, 18.0, 4, "UserB")
+        );
+        when(routeRankingRepository.findFastestRoutes()).thenReturn(expectedRankings);
+
+        // Act
+        List<RouteRanking> actualRankings = routeRankingService.getFastestRoutes();
+
+        // Assert
+        assertNotNull(actualRankings);
+        assertEquals(expectedRankings.size(), actualRankings.size());
+        assertEquals(expectedRankings, actualRankings);
+        verify(routeRankingRepository, times(1)).findFastestRoutes();
+    }
+
+    @Test
+    void testGetFastestRoutes_Empty() {
+        // Arrange
+        when(routeRankingRepository.findFastestRoutes()).thenReturn(Collections.emptyList());
+
+        // Act
+        List<RouteRanking> actualRankings = routeRankingService.getFastestRoutes();
+
+        // Assert
+        assertNotNull(actualRankings);
+        assertEquals(0, actualRankings.size());
+        verify(routeRankingRepository, times(1)).findFastestRoutes();
+    }
+
+    @Test
+    void testGetShortestRoutes() {
+        // Arrange
+        List<RouteRanking> expectedRankings = Arrays.asList(
+                new RouteRanking("R003", "Shortest Route 1", 5.0, 25.0, 5, "UserC"),
+                new RouteRanking("R004", "Shortest Route 2", 6.2, 22.0, 2, "UserD")
+        );
+        when(routeRankingRepository.findShortestRoutes()).thenReturn(expectedRankings);
+
+        // Act
+        List<RouteRanking> actualRankings = routeRankingService.getShortestRoutes();
+
+        // Assert
+        assertNotNull(actualRankings);
+        assertEquals(expectedRankings.size(), actualRankings.size());
+        assertEquals(expectedRankings, actualRankings);
+        verify(routeRankingRepository, times(1)).findShortestRoutes();
+    }
+
+    @Test
+    void testGetShortestRoutes_Empty() {
+        // Arrange
+        when(routeRankingRepository.findShortestRoutes()).thenReturn(Collections.emptyList());
+
+        // Act
+        List<RouteRanking> actualRankings = routeRankingService.getShortestRoutes();
+
+        // Assert
+        assertNotNull(actualRankings);
+        assertEquals(0, actualRankings.size());
+        verify(routeRankingRepository, times(1)).findShortestRoutes();
+    }
+
+    @Test
+    void testGetSafestRoutes() {
+        // Arrange
+        List<RouteRanking> expectedRankings = Arrays.asList(
+                new RouteRanking("R005", "Safest Route 1", 8.0, 30.0, 5, "UserE"),
+                new RouteRanking("R006", "Safest Route 2", 7.5, 28.0, 5, "UserF")
+        );
+        when(routeRankingRepository.findSafestRoutes()).thenReturn(expectedRankings);
+
+        // Act
+        List<RouteRanking> actualRankings = routeRankingService.getSafestRoutes();
+
+        // Assert
+        assertNotNull(actualRankings);
+        assertEquals(expectedRankings.size(), actualRankings.size());
+        assertEquals(expectedRankings, actualRankings);
+        verify(routeRankingRepository, times(1)).findSafestRoutes();
+    }
+
+    @Test
+    void testGetSafestRoutes_Empty() {
+        // Arrange
+        when(routeRankingRepository.findSafestRoutes()).thenReturn(Collections.emptyList());
+
+        // Act
+        List<RouteRanking> actualRankings = routeRankingService.getSafestRoutes();
+
+        // Assert
+        assertNotNull(actualRankings);
+        assertEquals(0, actualRankings.size());
+        verify(routeRankingRepository, times(1)).findSafestRoutes();
+    }
+}

--- a/src/test/java/com/osc/saferoute/controller/RouteRankingControllerTest.java
+++ b/src/test/java/com/osc/saferoute/controller/RouteRankingControllerTest.java
@@ -1,0 +1,122 @@
+package com.osc.saferoute.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.osc.saferoute.application.service.RouteRankingService;
+import com.osc.saferoute.domain.model.RouteRanking;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+
+@WebMvcTest(RouteRankingController.class)
+public class RouteRankingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RouteRankingService routeRankingService;
+
+    @Autowired
+    private ObjectMapper objectMapper; // For converting objects to JSON strings if needed for complex assertions
+
+    @Test
+    void testGetRankedRoutes_Fastest() throws Exception {
+        // Arrange
+        List<RouteRanking> fastestRoutes = Arrays.asList(
+                new RouteRanking("R001", "Fastest Route 1", 10.0, 15.0, 3, "UserA"),
+                new RouteRanking("R002", "Fastest Route 2", 12.5, 18.0, 4, "UserB")
+        );
+        when(routeRankingService.getFastestRoutes()).thenReturn(fastestRoutes);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/rankings/routes?type=fastest"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].routeId", is("R001")))
+                .andExpect(jsonPath("$[0].routeName", is("Fastest Route 1")))
+                .andExpect(jsonPath("$[1].routeId", is("R002")))
+                .andExpect(jsonPath("$[1].routeName", is("Fastest Route 2")));
+    }
+
+    @Test
+    void testGetRankedRoutes_Shortest() throws Exception {
+        // Arrange
+        List<RouteRanking> shortestRoutes = Arrays.asList(
+                new RouteRanking("R003", "Shortest Route 1", 5.0, 25.0, 5, "UserC"),
+                new RouteRanking("R004", "Shortest Route 2", 6.2, 22.0, 2, "UserD")
+        );
+        when(routeRankingService.getShortestRoutes()).thenReturn(shortestRoutes);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/rankings/routes?type=shortest"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].routeId", is("R003")))
+                .andExpect(jsonPath("$[0].distance", is(5.0)))
+                .andExpect(jsonPath("$[1].routeId", is("R004")))
+                .andExpect(jsonPath("$[1].distance", is(6.2)));
+    }
+
+    @Test
+    void testGetRankedRoutes_Safest() throws Exception {
+        // Arrange
+        List<RouteRanking> safestRoutes = Arrays.asList(
+                new RouteRanking("R005", "Safest Route 1", 8.0, 30.0, 5, "UserE"),
+                new RouteRanking("R006", "Safest Route 2", 7.5, 28.0, 5, "UserF")
+        );
+        when(routeRankingService.getSafestRoutes()).thenReturn(safestRoutes);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/rankings/routes?type=safest"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].routeId", is("R005")))
+                .andExpect(jsonPath("$[0].selfAssessedSafety", is(5)))
+                .andExpect(jsonPath("$[1].routeId", is("R006")))
+                .andExpect(jsonPath("$[1].selfAssessedSafety", is(5)));
+    }
+
+    @Test
+    void testGetRankedRoutes_Safest_Empty() throws Exception {
+        // Arrange
+        when(routeRankingService.getSafestRoutes()).thenReturn(Collections.emptyList());
+
+        // Act & Assert
+        mockMvc.perform(get("/api/rankings/routes?type=safest"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+
+    @Test
+    void testGetRankedRoutes_InvalidType() throws Exception {
+        // Act & Assert
+        mockMvc.perform(get("/api/rankings/routes?type=nonexistent"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void testGetRankedRoutes_NoType() throws Exception {
+        // Act & Assert
+        mockMvc.perform(get("/api/rankings/routes"))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
Adds a new API endpoint `/api/rankings/routes` to fetch evacuation routes ranked by different criteria.

The endpoint accepts a `type` query parameter, which can be one of:
- `fastest`: Routes ordered by `estimated_time` (ascending).
- `shortest`: Routes ordered by `distance` (ascending).
- `safest`: Routes ordered by `self_assessed_safety` (descending).

The implementation follows the existing Onion architecture:
- A `RouteRanking` domain model holds the combined route and user information.
- `RouteRankingRepository` and its MyBatis implementation `MyBatisRouteRankingRepository` handle database interaction.
- `RouteRankingMapper.xml` and `RouteRankingMapper.java` define the SQL queries and MyBatis mapping.
- `RouteRankingService` orchestrates the logic.
- `RouteRankingController` exposes the HTTP GET endpoint.

Unit tests have been added for the service and controller layers to ensure correctness. The primary tables involved are `evacuation_routes` (columns: `distance`, `estimated_time`, `self_assessed_safety`) and `users` (column: `nickname`).